### PR TITLE
Hide Navbar when not logged in.

### DIFF
--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -2,13 +2,13 @@
 <div class="container-fluid">
   <!-- Brand and toggle get grouped for better mobile display -->
   <div class="navbar-header">
+    <% if logged_in? %>
     <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#bs-example-navbar-collapse-1" aria-expanded="false">
       <span class="sr-only">Toggle navigation</span>
       <span class="icon-bar"></span>
       <span class="icon-bar"></span>
       <span class="icon-bar"></span>
     </button>
-  <% if logged_in? %>
     <a class="navbar-brand" href="/tasks">Turtle-Shell.io</a>
   <% else %>
     <a class="navbar-brand" href="/">Turtle-Shell.io</a>


### PR DESCRIPTION
A user reported that the menu wasn't working on mobile but after some
looking into it, the cause was because all the links in the mobile
hamburger menu were not shown due to their need to be logged in.

I have hidden the hamburger menu for now until they are logged in, or
until we add another page accessible via a non user